### PR TITLE
Update MatchTimeline to use region when constructing url

### DIFF
--- a/riot/lol/match.go
+++ b/riot/lol/match.go
@@ -134,8 +134,10 @@ func (m *MatchClient) ListStream(puuid string, options ...*MatchListOptions) <-c
 // TODO: double check v5 implementation when struct is documented
 func (m *MatchClient) GetTimeline(id string) (*MatchTimeline, error) {
 	logger := m.logger().WithField("method", "GetTimeline")
+	c := *m.c                                          // copy client
+	c.Region = api.Region(api.RegionToRoute[c.Region]) // Match v5 uses a route instead of a region
 	var timeline MatchTimeline
-	if err := m.c.GetInto(fmt.Sprintf(endpointGetMatchTimeline, id), &timeline); err != nil {
+	if err := c.GetInto(fmt.Sprintf(endpointGetMatchTimeline, id), &timeline); err != nil {
 		logger.Debug(err)
 		return nil, err
 	}

--- a/riot/lol/match_test.go
+++ b/riot/lol/match_test.go
@@ -168,7 +168,7 @@ func TestMatchClient_GetTimeline(t *testing.T) {
 			region: api.RegionEuropeWest,
 			doer: &mock.Doer{
 				Custom: func(r *http.Request) (*http.Response, error) {
-					assert.Equal(t, api.RegionToRoute[api.RegionEuropeWest], r.Host)
+					assert.Equal(t, fmt.Sprintf("%s.api.riotgames.com", api.RegionToRoute[api.RegionEuropeWest]), r.Host)
 					return mock.NewJSONMockDoer(MatchTimeline{}, 200).Do(r)
 				},
 			},


### PR DESCRIPTION
It looks like the other endpoints in match.go already had this change. I'm including it with my existing PR because the matchTimeline method won't work without it.