### PR TITLE
Implement league-exp-v4 endpoints

### DIFF
--- a/riot/lol/constants.go
+++ b/riot/lol/constants.go
@@ -27,6 +27,8 @@ const (
 	endpointGetLeaguesByPuuid                   = endpointLeagueBase + "/entries/by-puuid/%s"
 	endpointGetLeagues                          = endpointLeagueBase + "/entries/%s/%s/%s"
 	endpointGetLeague                           = endpointLeagueBase + "/leagues/%s"
+	endpointLeagueExpBase                       = endpointBase + "/league-exp/v4"
+	endpointGetLeagueExpEntries                 = endpointLeagueExpBase + "/entries/%s/%s/%s"
 	endpointStatusBase                          = endpointBase + "/status/v3"
 	endpointGetStatus                           = endpointStatusBase + "/shard-data"
 	endpointMatchBase                           = endpointBase + "/match/v5"

--- a/riot/lol/league.go
+++ b/riot/lol/league.go
@@ -79,6 +79,17 @@ func (l *LeagueClient) ListPlayers(queue queue, tier tier, division division) ([
 	return leagues, nil
 }
 
+// ListExpPlayers returns all players with a league specified by its queue, tier and division
+func (l *LeagueClient) ListExpPlayers(queue queue, tier tier, division division) ([]*LeagueItem, error) {
+	logger := l.logger().WithField("method", "ListExpPlayers")
+	var leagues []*LeagueItem
+	if err := l.c.GetInto(fmt.Sprintf(endpointGetLeagueExpEntries, queue, tier, division), &leagues); err != nil {
+		logger.Debug(err)
+		return nil, err
+	}
+	return leagues, nil
+}
+
 // Get returns a ranked league with the specified ID
 func (l *LeagueClient) Get(leagueID string) (*LeagueList, error) {
 	logger := l.logger().WithField("method", "Get")

--- a/riot/lol/league_test.go
+++ b/riot/lol/league_test.go
@@ -245,3 +245,36 @@ func TestLeagueClient_Get(t *testing.T) {
 		)
 	}
 }
+
+func TestLeagueClient_ListExpPlayers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*LeagueItem
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*LeagueItem{},
+			doer: mock.NewJSONMockDoer([]*LeagueItem{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).ListExpPlayers(QueueRankedSolo, TierGold, DivisionOne)
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
I'm not really sure what value this endpoint provides over the standard GetLeagues endpoint. I'm adding it for the sake of completionism, not because it seems necessary.

- Added ListExpPlayers method to LeagueClient
- Added endpointLeagueExpBase and endpointGetLeagueExpEntries keywords