### PR TITLE
Remove deprecated league v4 list by summoner

### DIFF
--- a/riot/lol/constants.go
+++ b/riot/lol/constants.go
@@ -23,7 +23,6 @@ const (
 	endpointGetChallengerLeague                 = endpointLeagueBase + "/challengerleagues/by-queue/%s"
 	endpointGetGrandmasterLeague                = endpointLeagueBase + "/grandmasterleagues/by-queue/%s"
 	endpointGetMasterLeague                     = endpointLeagueBase + "/masterleagues/by-queue/%s"
-	endpointGetLeaguesBySummoner                = endpointLeagueBase + "/entries/by-summoner/%s"
 	endpointGetLeaguesByPuuid                   = endpointLeagueBase + "/entries/by-puuid/%s"
 	endpointGetLeagues                          = endpointLeagueBase + "/entries/%s/%s/%s"
 	endpointGetLeague                           = endpointLeagueBase + "/leagues/%s"

--- a/riot/lol/league.go
+++ b/riot/lol/league.go
@@ -46,17 +46,6 @@ func (l *LeagueClient) GetMaster(queue queue) (*LeagueList, error) {
 	return list, nil
 }
 
-// ListBySummoner returns all leagues a summoner with the given ID is in
-func (l *LeagueClient) ListBySummoner(summonerID string) ([]*LeagueItem, error) {
-	logger := l.logger().WithField("method", "ListBySummoner")
-	var leagues []*LeagueItem
-	if err := l.c.GetInto(fmt.Sprintf(endpointGetLeaguesBySummoner, summonerID), &leagues); err != nil {
-		logger.Debug(err)
-		return nil, err
-	}
-	return leagues, nil
-}
-
 // ListByPuuid returns all leagues a summoner with the given puuid is in
 func (l *LeagueClient) ListByPuuid(puuid string) ([]*LeagueItem, error) {
 	logger := l.logger().WithField("method", "ListByPuuid")

--- a/riot/lol/league_test.go
+++ b/riot/lol/league_test.go
@@ -146,39 +146,6 @@ func TestLeagueClient_ListPlayers(t *testing.T) {
 	}
 }
 
-func TestLeagueClient_ListBySummoner(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		want    []*LeagueItem
-		doer    internal.Doer
-		wantErr error
-	}{
-		{
-			name: "get response",
-			want: []*LeagueItem{},
-			doer: mock.NewJSONMockDoer([]*LeagueItem{}, 200),
-		},
-		{
-			name:    "not found",
-			wantErr: api.ErrNotFound,
-			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(
-			tt.name, func(t *testing.T) {
-				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-				got, err := (&LeagueClient{c: client}).ListBySummoner("id")
-				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-				if tt.wantErr == nil {
-					assert.Equal(t, got, tt.want)
-				}
-			},
-		)
-	}
-}
-
 func TestLeagueClient_ListByPuuid(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
- Removed ListBySummoner method from LeagueClient
- Removed endpointGetLeaguesBySummoner constant
- Removed TestLeagueClient_ListBySummoner